### PR TITLE
include header for uint32_t and uint64_t types

### DIFF
--- a/opt/opt.h
+++ b/opt/opt.h
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <list>
 #include <vector>
+#include <cstdint>
 #include "err/err.h"
 
 ///\addtogroup libmapsoft


### PR DESCRIPTION
Build fix for gcc 13.1 .